### PR TITLE
Update exam countdown dates and metadata for 2026

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-    "short_name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2024 Coutdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2023/2024/2025",
-    "name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2024 Coutdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2023/2024/2025 ",
-    "description": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2024 Coutdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2023/2024/2025",
+    "short_name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2026 Countdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2024/2025/2026",
+    "name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2026 Countdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2024/2025/2026 ",
+    "description": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2026 Countdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2024/2025/2026",
     "icons": [
         {
             "src": "/favicon.ico",
@@ -17,9 +17,9 @@
     "theme_color": "#F2F5F1",
     "shortcuts": [
         {
-            "name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2025 Coutdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2023/2024/2025/2026",
-            "short_name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2025 Coutdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2023/2024/2025/2026",
-            "description": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2025 Coutdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2023/2024/2025/2026",
+            "name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2026 Countdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2024/2025/2026",
+            "short_name": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2026 Countdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2024/2025/2026",
+            "description": "JEE Mains, JEE ADV, NEET, BITSAT, MHTCET, WBJEE 2026 Countdown/TimeKeeper | JeeNeeTards Countdown/Timer for Exams like JEE, NEET, BITSAT 2024/2025/2026",
             "url": "/today?source=pwa",
             "icons": [
                 {

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JeeNeeTards Countdown/Timer/TimerKeeper for Exams</title>
-    <meta name="description" content="JEE NEET BITSAT Exam Countdown Timer 2023/2024/2025 | JeeNeeTards: Your Ultimate Preparation TimeKeeper Tool for JEE Main, JEE Advanced, NEET-UG, and BITSAT. Stay Motivated with Real-Time Countdowns. Ace Your Entrance Exams!">
+    <meta name="description" content="JEE NEET BITSAT Exam Countdown Timer 2024/2025/2026 | JeeNeeTards: Your Ultimate Preparation TimeKeeper Tool for JEE Main, JEE Advanced, NEET-UG, and BITSAT. Stay Motivated with Real-Time Countdowns. Ace Your Entrance Exams!">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <style>
         #popup-container {

--- a/src/components/custom-minibar.svelte
+++ b/src/components/custom-minibar.svelte
@@ -1,8 +1,8 @@
 <script>
     import { onMount } from 'svelte';
-    import examsData from '../data/2025.json';
+    import examsData from '../data/2026.json';
     
-    let year = 2025; 
+    let year = 2026;
     let { exams } = examsData;
     let countdowns = [];
     let showAddForm = false;
@@ -38,7 +38,7 @@
       if (savedYear) {
         year = parseInt(savedYear);
       } else {
-        year = 2025;
+        year = 2026;
       }
     
       if (savedCountdowns && savedAvailableExams) {

--- a/src/components/minibar.svelte
+++ b/src/components/minibar.svelte
@@ -1,10 +1,10 @@
 <script>
-  let jeeMainsYear = "Jee Mains 25";
-  let jeeadvanced = "Jee Adv 25";
-  let neet = "NEET 25";
-  let bitsat = "BITSAT 25";
-  let mhtcet = "MHT-CET 25";
-  let wbjee = "WBJEE 25";
+  let jeeMainsYear = "Jee Mains 26";
+  let jeeadvanced = "Jee Adv 26";
+  let neet = "NEET 26";
+  let bitsat = "BITSAT 26";
+  let mhtcet = "MHT-CET 26";
+  let wbjee = "WBJEE 26";
 </script>
 
 <hr />
@@ -141,17 +141,17 @@
 
     var eventsx = [
       // JEE Mains [xtimer1]
-      { name: "Event x1", datex: new Date("Apr 09, 2025 00:00:00").getTime() },
+      { name: "Event x1", datex: new Date("Jan 24, 2026 00:00:00").getTime() },
       // JEE Adv [xtimer2]
-      { name: "Event x2", datex: new Date("May 18, 2025 00:00:00").getTime() },
+      { name: "Event x2", datex: new Date("May 26, 2026 00:00:00").getTime() },
       // NEET [xtimer3]
-      { name: "Event x3", datex: new Date("May 04, 2025 00:00:00").getTime() },
+      { name: "Event x3", datex: new Date("May 05, 2026 00:00:00").getTime() },
       // BITSAT [xtimer4]
-      { name: "Event x4", datex: new Date("May 26, 2025 00:00:00").getTime() },
+      { name: "Event x4", datex: new Date("May 20, 2026 00:00:00").getTime() },
       // MHTCET [xtimer5]
-      { name: "Event x5", datex: new Date("Apr 19, 2025 00:00:00").getTime() },
+      { name: "Event x5", datex: new Date("Apr 22, 2026 00:00:00").getTime() },
       // WBJEE [xtimer6]
-      { name: "Event x6", datex: new Date("Apr 27, 2025 00:00:00").getTime() },
+      { name: "Event x6", datex: new Date("Apr 28, 2026 00:00:00").getTime() },
     ];
 
     var countdownsx = [];

--- a/src/components/timer.astro
+++ b/src/components/timer.astro
@@ -8,15 +8,15 @@ import "../../src/global.css";
   <script>
     var events = [
   // JEE [timer1]
-  { name: "Event 1", date: new Date("Apr 09, 2025 00:00:00").getTime() },
+  { name: "Event 1", date: new Date("Jan 24, 2026 00:00:00").getTime() },
   // JEE Adv Date [timer2]
-  { name: "Event 2", date: new Date("May 18, 2025 00:00:00").getTime() },
+  { name: "Event 2", date: new Date("May 26, 2026 00:00:00").getTime() },
   // NEET [timer3]
-  { name: "Event 3", date: new Date("May 04, 2025 00:00:00").getTime() },
+  { name: "Event 3", date: new Date("May 05, 2026 00:00:00").getTime() },
   // BITSAT [timer4]
-  { name: "Event 4", date: new Date("May 26, 2025 00:00:00").getTime() },
+  { name: "Event 4", date: new Date("May 20, 2026 00:00:00").getTime() },
   // MHTCET [timer5]
-  { name: "Event 5", date: new Date("Apr 19, 2025 00:00:00").getTime() },
+  { name: "Event 5", date: new Date("Apr 22, 2026 00:00:00").getTime() },
 ];
 
 var countdowns = events.map((event, i) => ({

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ import NotificationHeader from "../components/NotificationHeader.astro";
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <title>
-      Exam Countdown & TimerKeeper for Exams like JEE, NEET, BITSAT 2023/2024/2025
+      Exam Countdown & TimerKeeper for Exams like JEE, NEET, BITSAT 2024/2025/2026
     </title>
     <meta
       name="description"

--- a/src/pages/custom/countdown.astro
+++ b/src/pages/custom/countdown.astro
@@ -55,7 +55,7 @@ import CustomMinibar from "../../components/custom-minibar.svelte";
                 class="block overflow-hidden rounded-md border border-gray-200 px-3 py-2 shadow-sm focus-within:border-rose-200 focus-within:ring-1 focus-within:ring-rose-200"
             >
                 <span class="text-xs font-medium text-gray-500">Year-Month-Day</span>
-                <input class="mt-1 w-full rounded-md pl-2 border-gray-200 shadow-sm sm:text-sm" type="text" placeholder="2025-07-24" id="endtime" value=""> 
+                <input class="mt-1 w-full rounded-md pl-2 border-gray-200 shadow-sm sm:text-sm" type="text" placeholder="2026-12-31" id="endtime" value="">
             </label>  
         <div class="py-2">
             <a id="start-count" class="mx-auto text-center w-full inline-block rounded border border-rose-200 bg-rose-200 px-12 py-3 text-sm font-medium text-black hover:bg-transparent hover:text-rose-300 focus:outline-none focus:ring active:text-rose-200" id="start-count">Start</a>

--- a/src/pages/exams/bitsat.astro
+++ b/src/pages/exams/bitsat.astro
@@ -6,15 +6,15 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <head>
-  <title>BITSAT | 2025 | Countdown | TimeKeeper</title>
+  <title>BITSAT | 2026 | Countdown | TimeKeeper</title>
 </head>
-<Layout title="JeeNeeTards | TimeKeeper Countdown for BITSAT 2025" description="Ultimate BITSAT 2025 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for BITSAT aspirants.">
+<Layout title="JeeNeeTards | TimeKeeper Countdown for BITSAT 2026" description="Ultimate BITSAT 2026 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for BITSAT aspirants.">
   <hr />
   <section>
     <main>
       <div class="flex flex-col items-center" id="timerbase">
         <h1 class="text-5xl md:text-3xl font-bold text-center py-12">
-          BITSAT 25
+          BITSAT 26
         </h1>
         <div class="pb-16" id="timer4"></div>
       </div>

--- a/src/pages/exams/jeeadvanced.astro
+++ b/src/pages/exams/jeeadvanced.astro
@@ -6,15 +6,15 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <head>
-  <title>JEE Advanced | 2025 | Countdown | TimeKeeper</title>
+  <title>JEE Advanced | 2026 | Countdown | TimeKeeper</title>
 </head>
 
-<Layout title="JeeNeeTards | TimeKeeper Countdown for JEE Advanced 2025" description="Ultimate JEE Advanced 2025 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for JEE Advanced aspirants.">
+<Layout title="JeeNeeTards | TimeKeeper Countdown for JEE Advanced 2026" description="Ultimate JEE Advanced 2026 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for JEE Advanced aspirants.">
   <section>
     <main>
       <div class="flex flex-col items-center" id="timerbase">
         <h1 class="text-5xl md:text-3xl font-bold text-center py-12">
-          Jee Adv 25
+          Jee Adv 26
         </h1>
         <div class="pb-16" id="timer2"></div>
       </div>

--- a/src/pages/exams/jeemains.astro
+++ b/src/pages/exams/jeemains.astro
@@ -6,9 +6,9 @@ import Minibar from "../../components/minibar.svelte";
 ---
 
 <head>
-  <title>JEE Mains | 2025 | Countdown | TimeKeeper</title>
+  <title>JEE Mains | 2026 | Countdown | TimeKeeper</title>
 </head>
-<Layout title="JeeNeeTards | TimeKeeper Countdown for JEE Mains 2025" description="Ultimate JEE Mains 2025 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for JEE Mains aspirants.">
+<Layout title="JeeNeeTards | TimeKeeper Countdown for JEE Mains 2026" description="Ultimate JEE Mains 2026 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for JEE Mains aspirants.">
   <section>
     <main>
       <div class="flex flex-col items-center py-12" id="timerbase">
@@ -16,7 +16,7 @@ import Minibar from "../../components/minibar.svelte";
           Jee Mains <br />
         </h1>
         <h2 class="text-2xl md:text-2xl font-bold text-center pt-2 pb-10">
-          (01st Apr 25) 
+          (24th Jan 26)
         </h2>
         <div class="pb-16" id="timer1"></div>
       </div>

--- a/src/pages/exams/mhtcet.astro
+++ b/src/pages/exams/mhtcet.astro
@@ -6,16 +6,16 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <head>
-  <title>MHT-CET (MHTCET) | 2025 | Countdown | TimeKeeper</title>
+  <title>MHT-CET (MHTCET) | 2026 | Countdown | TimeKeeper</title>
 </head>
 
-<Layout title="JeeNeeTards | TimeKeeper Countdown for MHT-CET (MHTCET) 2025" description="Ultimate MHT-CET (MHTCET) 2025 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for MHT-CET (MHTCET) aspirants.">
+<Layout title="JeeNeeTards | TimeKeeper Countdown for MHT-CET (MHTCET) 2026" description="Ultimate MHT-CET (MHTCET) 2026 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for MHT-CET (MHTCET) aspirants.">
   <hr />
   <section>
     <main>
       <div class="flex flex-col items-center" id="timerbase">
         <h1 class="text-5xl md:text-3xl font-bold text-center py-12">
-          MHT-CET 25
+          MHT-CET 26
         </h1>
         <div class="pb-16" id="timer5"></div>
       </div>

--- a/src/pages/exams/neet.astro
+++ b/src/pages/exams/neet.astro
@@ -6,9 +6,9 @@ import Layout from "../../layouts/Layout.astro";
 ---
 
 <head>
-  <title>NEET | 2025 | Countdown | TimeKeeper</title>
+  <title>NEET | 2026 | Countdown | TimeKeeper</title>
 </head>
-<Layout title="JeeNeeTards | TimeKeeper Countdown for NEET 2025" description="Ultimate NEET 2025 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for NEET aspirants.">
+<Layout title="JeeNeeTards | TimeKeeper Countdown for NEET 2026" description="Ultimate NEET 2026 countdown timer. Track days, hours, minutes til exam. Stay motivated, manage time efficiently. Essential tool for NEET aspirants.">
   <section>
     <main>
       <div class="flex flex-col items-center py-12" id="timerbase">
@@ -16,7 +16,7 @@ import Layout from "../../layouts/Layout.astro";
           Neet <br />
         </h1>
         <h2 class="text-2xl md:text-2xl font-bold text-center pt-2 pb-10">
-          (5th May 25)
+          (5th May 26)
         </h2>
         <div class="pb-16" id="timer3"></div>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import Cardx from "../components/cardx.astro";
 import "../global.css";
 ---
 
-<Layout title="TimeKeeper | Countdown | JeeNeeTards" description="Ace JEE Mains, Advanced, BITSAT, NEET 2025-2026! Ultimate exam countdown tool for aspiring engineers and medical students. Track JEE, BITSAT, MHTCET, NEET & WBJEE deadlines. Customizable timers for all entrance exams. Stay motivated, manage time effectively. #JEEPrep #NEETCountdown #EntranceExams">
+<Layout title="TimeKeeper | Countdown | JeeNeeTards" description="Ace JEE Mains, Advanced, BITSAT, NEET 2026! Ultimate exam countdown tool for aspiring engineers and medical students. Track JEE, BITSAT, MHTCET, NEET & WBJEE deadlines. Customizable timers for all entrance exams. Stay motivated, manage time effectively. #JEEPrep #NEETCountdown #EntranceExams">
   <main>
     <h1 class="text-5xl md:text-5xl font-black text-center py-4">Welcome to <span class="text-gradient">TimeKeeper</span></h1>
   </main>


### PR DESCRIPTION
### Motivation
- The app's exam countdowns, labels, and metadata were still pointing to 2025/older cycles and needed to be updated to the 2026 exam cycle.
- Update the default dataset used for customizable countdowns so new user defaults reflect 2026 schedules.

### Description
- Updated primary countdown targets in `src/components/timer.astro` to the 2026 exam dates (JEE Mains, JEE Advanced, NEET, BITSAT, MHT-CET).
- Updated minibar labels and minibar countdown dates in `src/components/minibar.svelte` to show 2026 and synchronized all six minibars (including WBJEE) to 2026 dates.
- Switched customizable countdown defaults to the 2026 dataset by importing `src/data/2026.json` and changing the default year in `src/components/custom-minibar.svelte`.
- Updated per-exam pages and displayed copy (titles, headings, and shown dates) in `src/pages/exams/*.astro`, updated site metadata in `manifest.json`, `src/components/Head.astro`, `src/layouts/Layout.astro`, and adjusted the custom countdown placeholder in `src/pages/custom/countdown.astro` and the site index text in `src/pages/index.astro` to reference 2026.

### Testing
- Ran `npm run build` and the Astro build completed successfully (client and server bundles produced). 
- Ran `git diff --check` and no trailing/diff-check issues remained after fixes. 
- Verified repository status with `git status --short` to ensure changes were staged/committed as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cb6b1804c832dba8ccc49668a718c)